### PR TITLE
Update file_carrier.go

### DIFF
--- a/api/helper/file_carrier.go
+++ b/api/helper/file_carrier.go
@@ -343,7 +343,7 @@ func (f *FileHandle) WriteToDisk(r *http.Request, fieldName string) error {
     PrivateTestCategory,
     SubmissionCategory:
     switch givenContentType {
-    case "application/zip", "application/octet-stream":
+    case "application/zip", "application/x-zip-compressed", "application/octet-stream":
 
     default:
       return errors.New(fmt.Sprintf("We support ZIP files only. But %s was given", givenContentType))


### PR DESCRIPTION
`application/x-zip-compressed`  ist anscheinend auch ein valider MIME-Type für ZIP-Dateien.
Chrome 75 lädt Dateien damit hoch, die Abgabe schlägt fehl.